### PR TITLE
feat: restrict points and guides to image canvas boundary

### DIFF
--- a/src/application/services/canvasHandler/canvasHandler.ts
+++ b/src/application/services/canvasHandler/canvasHandler.ts
@@ -10,6 +10,7 @@ export class CanvasHandler implements CanvasHandlerInterface {
   imageElement: HTMLImageElement
   scale = 1
   cursor: Coord = { xPx: 0, yPx: 0 }
+  isCursorOnCanvas = false
   rectangle = {
     startX: 0,
     startY: 0,

--- a/src/application/services/canvasHandler/canvasHandlerInterface.ts
+++ b/src/application/services/canvasHandler/canvasHandlerInterface.ts
@@ -6,6 +6,7 @@ export interface CanvasHandlerInterface {
   imageElement: HTMLImageElement
   scale: number
   cursor: Coord
+  isCursorOnCanvas: boolean
   manualMode: ManualMode
   maskMode: MaskMode
   rectangle: {

--- a/src/presentation/components/Canvas/CanvasAxis.vue
+++ b/src/presentation/components/Canvas/CanvasAxis.vue
@@ -1,5 +1,11 @@
 <template>
-  <div v-if="axis.coordIsFilled || isActive || isNextAxis" v-show="isVisible">
+  <div
+    v-if="
+      axis.coordIsFilled ||
+      ((isActive || isNextAxis) && canvasHandler.isCursorOnCanvas)
+    "
+    v-show="isVisible"
+  >
     <!-- Click area (larger for easier interaction) -->
     <div
       v-if="

--- a/src/presentation/components/Canvas/CanvasAxisSetGuide.vue
+++ b/src/presentation/components/Canvas/CanvasAxisSetGuide.vue
@@ -46,8 +46,12 @@ export default defineComponent({
       )
     },
     isX1Y1LineVisible(): boolean {
+      // INFO: 軸が確定済みなら常に表示、未確定ならカーソルがキャンバス上にある時のみ表示
+      if (this.axisSetRepository.activeAxisSet.x1.coordIsFilled) {
+        return true
+      }
       return (
-        this.axisSetRepository.activeAxisSet.x1.coordIsFilled ||
+        this.canvasHandler.isCursorOnCanvas &&
         this.canvasHandler.scaledCursor.xPx !== 0
       )
     },

--- a/src/presentation/components/Canvas/CanvasCursor.vue
+++ b/src/presentation/components/Canvas/CanvasCursor.vue
@@ -3,6 +3,7 @@
     <!-- INFO: right label -->
     <div
       v-if="
+        canvasHandler.isCursorOnCanvas &&
         !datasetRepository.isViewAllMode &&
         !(
           axisSetRepository.activeAxisSet.isAdjusting ||
@@ -103,6 +104,10 @@ export default defineComponent({
       return ''
     },
     isCursorGuideLinesActive(): boolean {
+      // INFO: カーソルがキャンバス外の場合は非表示
+      if (!this.canvasHandler.isCursorOnCanvas) {
+        return false
+      }
       //INFO: View All mode is read-only
       if (this.datasetRepository.isViewAllMode) {
         return false

--- a/src/presentation/components/Canvas/CanvasMain.vue
+++ b/src/presentation/components/Canvas/CanvasMain.vue
@@ -6,6 +6,8 @@
     @mousemove="mouseMove"
     @mousedown="mouseDown"
     @mouseup="mouseUp"
+    @mouseenter="mouseEnter"
+    @mouseleave="mouseLeave"
   >
     <canvas id="imageCanvas"></canvas>
     <canvas
@@ -124,19 +126,30 @@ export default defineComponent({
       }
       const target = e.target as HTMLElement
       const isOnCanvasPoint = target.className === 'canvas-point'
+
+      // INFO: クリック座標を画像のオリジナル座標に変換
+      const xPx = isOnCanvasPoint
+        ? (e.offsetX + parseFloat(target.style.left) - offsetPx) /
+          this.canvasHandler.scale
+        : (e.offsetX - offsetPx) / this.canvasHandler.scale
+      const yPx = isOnCanvasPoint
+        ? (e.offsetY + parseFloat(target.style.top)) / this.canvasHandler.scale
+        : e.offsetY / this.canvasHandler.scale
+
+      // INFO: 画像範囲外のクリックを無視する
+      if (
+        xPx < 0 ||
+        yPx < 0 ||
+        xPx > this.canvasHandler.originalWidth ||
+        yPx > this.canvasHandler.originalHeight
+      ) {
+        return
+      }
+
       // INFO: canvas-point element上の時は、point edit modeになるので
       switch (this.canvasHandler.manualMode) {
         case 0:
-          this.datasetRepository.activeDataset.addPoint(
-            isOnCanvasPoint
-              ? (e.offsetX + parseFloat(target.style.left) - offsetPx) /
-                  this.canvasHandler.scale
-              : (e.offsetX - offsetPx) / this.canvasHandler.scale,
-            isOnCanvasPoint
-              ? (e.offsetY + parseFloat(target.style.top)) /
-                  this.canvasHandler.scale
-              : e.offsetY / this.canvasHandler.scale,
-          )
+          this.datasetRepository.activeDataset.addPoint(xPx, yPx)
           this.axisSetRepository.activeAxisSet.inactivateAxis()
           this.datasetRepository.activeDataset.addManuallyAddedPointId(
             this.datasetRepository.activeDataset.lastPointId,
@@ -156,8 +169,8 @@ export default defineComponent({
       }
       if (this.axisSetRepository.activeAxisSet.nextAxis) {
         this.axisSetRepository.activeAxisSet.addAxisCoord({
-          xPx: (e.offsetX - offsetPx) / this.canvasHandler.scale,
-          yPx: e.offsetY / this.canvasHandler.scale,
+          xPx,
+          yPx,
         })
         this.datasetRepository.activeDataset.inactivatePoints()
         // INFO: 軸を全て設定し終えた後は自動でプロット追加モードにする
@@ -185,17 +198,33 @@ export default defineComponent({
     mouseMove(e: MouseEvent) {
       const { xPx, yPx } = getMouseCoordFromMouseEvent(e)
 
+      // INFO: カーソルが画像canvas要素の範囲内かどうかを判定
+      const cursorXPx = xPx / this.canvasHandler.scale
+      const cursorYPx = yPx / this.canvasHandler.scale
+      this.canvasHandler.isCursorOnCanvas =
+        cursorXPx >= 0 &&
+        cursorYPx >= 0 &&
+        cursorXPx <= this.canvasHandler.originalWidth &&
+        cursorYPx <= this.canvasHandler.originalHeight
+
       this.axisSetRepository.activeAxisSet.isAdjusting = false
       this.datasetRepository.activeDataset.pointsAreAdjusting = false
       this.canvasHandler.setCursor({
-        xPx: xPx / this.canvasHandler.scale,
-        yPx: yPx / this.canvasHandler.scale,
+        xPx: cursorXPx,
+        yPx: cursorYPx,
       })
       // INFO: 左クリックされていない状態
       const isClicking = e.buttons === 1
       if (isClicking) {
         this.mouseDrag({ xPx, yPx })
       }
+    },
+    mouseEnter() {
+      // INFO: 正確な判定はmouseMoveで行うが、初期値としてtrueにする
+      this.canvasHandler.isCursorOnCanvas = true
+    },
+    mouseLeave() {
+      this.canvasHandler.isCursorOnCanvas = false
     },
     mouseDown(e: MouseEvent) {
       if (this.datasetRepository.isViewAllMode) return


### PR DESCRIPTION
## Summary
- Prevent data points and calibration points from being placed outside the image area
- Hide cursor guide lines, axis labels, and axis markers when cursor leaves the image canvas region
- Detect boundary based on actual image dimensions (`originalWidth`/`originalHeight`), not the wrapper element

## Test plan
- [ ] Click outside image area (below/right of image) → no point added
- [ ] Move cursor outside image → guide lines and labels disappear
- [ ] Move cursor back onto image → guides reappear
- [ ] Confirmed axis markers remain visible when cursor leaves
- [ ] All existing E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)