### PR TITLE
feat: plot-digitizer-core Phase 3 (SerializeProjectUseCase移植)

### DIFF
--- a/packages/plot-digitizer-core/src/application/dto/axisDTO.ts
+++ b/packages/plot-digitizer-core/src/application/dto/axisDTO.ts
@@ -1,0 +1,12 @@
+import type { Coord } from '../../domain/types'
+
+/**
+ * DTO (Data Transfer Object) for Axis
+ * Plain data representation for serialization/deserialization
+ * This type contains only serializable properties
+ */
+export interface AxisDTO {
+  name: string
+  value: number
+  coord: Coord
+}

--- a/packages/plot-digitizer-core/src/application/dto/axisSetDTO.ts
+++ b/packages/plot-digitizer-core/src/application/dto/axisSetDTO.ts
@@ -1,0 +1,21 @@
+import type { AxisDTO } from './axisDTO'
+import type { PointMode } from '../../domain/types'
+
+/**
+ * DTO (Data Transfer Object) for AxisSet
+ * Plain data representation for serialization/deserialization
+ * Uses AxisDTO to ensure all nested properties are also serializable
+ */
+export interface AxisSetDTO {
+  id: number
+  name: string
+  x1: AxisDTO
+  x2: AxisDTO
+  y1: AxisDTO
+  y2: AxisDTO
+  xIsLogScale: boolean
+  yIsLogScale: boolean
+  considerGraphTilt: boolean
+  pointMode: PointMode
+  isVisible: boolean
+}

--- a/packages/plot-digitizer-core/src/application/dto/canvasStateDTO.ts
+++ b/packages/plot-digitizer-core/src/application/dto/canvasStateDTO.ts
@@ -1,0 +1,16 @@
+/**
+ * DTO (Data Transfer Object) for the small slice of canvas/view state that
+ * gets persisted alongside a project (scale, manual-edit mode).
+ *
+ * INFO: named `CanvasStateDTO` here, not `CanvasHandlerDTO` — core has no
+ * concept of "CanvasHandler" (that's a host-app, DOM-coupled class living in
+ * src/presentation/services/canvasHandler; see docs/design/
+ * plot-digitizer-architecture.md Phase 2). `manualMode` is a plain `number`
+ * for the same reason: the specific mode enum (MANUAL_MODE) is a host-app
+ * concept, not core's. The host app's DTO wrapper re-exports this type as
+ * `CanvasHandlerDTO` to keep its existing name/shape.
+ */
+export interface CanvasStateDTO {
+  scale: number
+  manualMode: number
+}

--- a/packages/plot-digitizer-core/src/application/dto/datasetDTO.ts
+++ b/packages/plot-digitizer-core/src/application/dto/datasetDTO.ts
@@ -1,0 +1,15 @@
+import type { Point } from '../../domain/types'
+
+/**
+ * DTO (Data Transfer Object) for Dataset
+ * Plain data representation for serialization/deserialization
+ * This type contains only serializable data properties
+ */
+export interface DatasetDTO {
+  id: number
+  name: string
+  axisSetId: number
+  points: Point[]
+  visiblePointIds: number[]
+  manuallyAddedPointIds: number[]
+}

--- a/packages/plot-digitizer-core/src/application/dto/projectDTO.ts
+++ b/packages/plot-digitizer-core/src/application/dto/projectDTO.ts
@@ -1,0 +1,22 @@
+import type { AxisSetDTO } from './axisSetDTO'
+import type { DatasetDTO } from './datasetDTO'
+import type { CanvasStateDTO } from './canvasStateDTO'
+
+/**
+ * DTO (Data Transfer Object) for Project
+ * Complete project data for serialization and deserialization
+ * This represents the entire application state that can be saved/loaded
+ *
+ * INFO: the `canvasHandler` field name is kept as-is (rather than
+ * `canvasState`) for backward file-format compatibility — existing
+ * `project.json` files exported by starry-digitizer already use this key.
+ */
+export interface ProjectDTO {
+  version: string
+  timestamp: string
+  axisSets: AxisSetDTO[]
+  activeAxisSetId: number
+  datasets: DatasetDTO[]
+  activeDatasetId: number
+  canvasHandler: CanvasStateDTO
+}

--- a/packages/plot-digitizer-core/src/application/useCases/serializeProjectUseCase.test.ts
+++ b/packages/plot-digitizer-core/src/application/useCases/serializeProjectUseCase.test.ts
@@ -1,0 +1,212 @@
+import { SerializeProjectUseCase } from './serializeProjectUseCase'
+import { Axis } from '../../domain/models/axis/axis'
+import { AxisSet } from '../../domain/models/axisSet/axisSet'
+import { Dataset } from '../../domain/models/dataset/dataset'
+import type { ProjectDTO } from '../dto/projectDTO'
+
+describe('SerializeProjectUseCase', () => {
+  const useCase = new SerializeProjectUseCase()
+
+  describe('toProjectDTO', () => {
+    test('maps axis sets, datasets, and canvas state into a ProjectDTO', () => {
+      const axisSet = new AxisSet(
+        new Axis('x1', 0, { xPx: 10, yPx: 110 }),
+        new Axis('x2', 100, { xPx: 110, yPx: 110 }),
+        new Axis('y1', 0, { xPx: 10, yPx: 110 }),
+        new Axis('y2', 100, { xPx: 10, yPx: 10 }),
+        new Axis('x2y2', -1, { xPx: -999, yPx: -999 }),
+        1,
+        'AxisSet 1',
+      )
+      axisSet.xIsLogScale = true
+      axisSet.considerGraphTilt = true
+
+      const dataset = new Dataset('Dataset 1', [{ id: 1, xPx: 5, yPx: 5 }], 1)
+      dataset.axisSetId = 1
+      dataset.visiblePointIds = [1]
+      dataset.manuallyAddedPointIds = [1]
+
+      const dto = useCase.toProjectDTO({
+        version: '1.11.2',
+        axisSets: [axisSet],
+        activeAxisSetId: 1,
+        datasets: [dataset],
+        activeDatasetId: 1,
+        canvasState: { scale: 1.5, manualMode: 0 },
+      })
+
+      expect(dto.version).toBe('1.11.2')
+      expect(typeof dto.timestamp).toBe('string')
+      expect(new Date(dto.timestamp).toString()).not.toBe('Invalid Date')
+
+      expect(dto.axisSets).toEqual([
+        {
+          id: 1,
+          name: 'AxisSet 1',
+          x1: { name: 'x1', value: 0, coord: { xPx: 10, yPx: 110 } },
+          x2: { name: 'x2', value: 100, coord: { xPx: 110, yPx: 110 } },
+          y1: { name: 'y1', value: 0, coord: { xPx: 10, yPx: 110 } },
+          y2: { name: 'y2', value: 100, coord: { xPx: 10, yPx: 10 } },
+          xIsLogScale: true,
+          yIsLogScale: false,
+          considerGraphTilt: true,
+          pointMode: 0,
+          isVisible: true,
+        },
+      ])
+      expect(dto.activeAxisSetId).toBe(1)
+      expect(dto.datasets).toEqual([
+        {
+          id: 1,
+          name: 'Dataset 1',
+          axisSetId: 1,
+          points: [{ id: 1, xPx: 5, yPx: 5 }],
+          visiblePointIds: [1],
+          manuallyAddedPointIds: [1],
+        },
+      ])
+      expect(dto.activeDatasetId).toBe(1)
+      expect(dto.canvasHandler).toEqual({ scale: 1.5, manualMode: 0 })
+    })
+
+    test('handles empty axisSets/datasets', () => {
+      const dto = useCase.toProjectDTO({
+        version: '1.0.0',
+        axisSets: [],
+        activeAxisSetId: 1,
+        datasets: [],
+        activeDatasetId: 1,
+        canvasState: { scale: 1, manualMode: -1 },
+      })
+
+      expect(dto.axisSets).toEqual([])
+      expect(dto.datasets).toEqual([])
+    })
+  })
+
+  describe('fromProjectDTO', () => {
+    const dto: ProjectDTO = {
+      version: '1.11.2',
+      timestamp: '2026-08-15T00:00:00.000Z',
+      axisSets: [
+        {
+          id: 1,
+          name: 'AxisSet 1',
+          x1: { name: 'x1', value: 0, coord: { xPx: 10, yPx: 110 } },
+          x2: { name: 'x2', value: 100, coord: { xPx: 110, yPx: 110 } },
+          y1: { name: 'y1', value: 0, coord: { xPx: 10, yPx: 110 } },
+          y2: { name: 'y2', value: 100, coord: { xPx: 10, yPx: 10 } },
+          xIsLogScale: true,
+          yIsLogScale: false,
+          considerGraphTilt: true,
+          pointMode: 1,
+          isVisible: false,
+        },
+      ],
+      activeAxisSetId: 1,
+      datasets: [
+        {
+          id: 1,
+          name: 'Dataset 1',
+          axisSetId: 1,
+          points: [{ id: 1, xPx: 5, yPx: 5 }],
+          visiblePointIds: [1],
+          manuallyAddedPointIds: [1],
+        },
+      ],
+      activeDatasetId: 1,
+      canvasHandler: { scale: 1.5, manualMode: 0 },
+    }
+
+    test('reconstructs AxisSet domain instances from the DTO', () => {
+      const result = useCase.fromProjectDTO(dto)
+
+      expect(result.axisSets).toHaveLength(1)
+      const axisSet = result.axisSets[0]
+      expect(axisSet).toBeInstanceOf(AxisSet)
+      expect(axisSet.id).toBe(1)
+      expect(axisSet.name).toBe('AxisSet 1')
+      expect(axisSet.x1).toEqual(
+        expect.objectContaining({
+          name: 'x1',
+          value: 0,
+          coord: { xPx: 10, yPx: 110 },
+        }),
+      )
+      expect(axisSet.x2.coord).toEqual({ xPx: 110, yPx: 110 })
+      expect(axisSet.y1.coord).toEqual({ xPx: 10, yPx: 110 })
+      expect(axisSet.y2.coord).toEqual({ xPx: 10, yPx: 10 })
+      expect(axisSet.xIsLogScale).toBe(true)
+      expect(axisSet.yIsLogScale).toBe(false)
+      expect(axisSet.considerGraphTilt).toBe(true)
+      expect(axisSet.pointMode).toBe(1)
+      expect(axisSet.isVisible).toBe(false)
+    })
+
+    test('always resets the x2y2 virtual axis rather than restoring it from the DTO', () => {
+      const result = useCase.fromProjectDTO(dto)
+      const axisSet = result.axisSets[0]
+
+      expect(axisSet.x2y2.name).toBe('x2y2')
+      expect(axisSet.x2y2.value).toBe(-1)
+      expect(axisSet.x2y2.coord).toEqual({ xPx: -999, yPx: -999 })
+    })
+
+    test('reconstructs Dataset domain instances from the DTO', () => {
+      const result = useCase.fromProjectDTO(dto)
+
+      expect(result.datasets).toHaveLength(1)
+      const dataset = result.datasets[0]
+      expect(dataset).toBeInstanceOf(Dataset)
+      expect(dataset.id).toBe(1)
+      expect(dataset.name).toBe('Dataset 1')
+      expect(dataset.axisSetId).toBe(1)
+      expect(dataset.points).toEqual([{ id: 1, xPx: 5, yPx: 5 }])
+      expect(dataset.visiblePointIds).toEqual([1])
+      expect(dataset.manuallyAddedPointIds).toEqual([1])
+    })
+
+    test('passes through activeAxisSetId / activeDatasetId / canvasState', () => {
+      const result = useCase.fromProjectDTO(dto)
+
+      expect(result.activeAxisSetId).toBe(1)
+      expect(result.activeDatasetId).toBe(1)
+      expect(result.canvasState).toEqual({ scale: 1.5, manualMode: 0 })
+    })
+
+    test('handles empty axisSets/datasets', () => {
+      const result = useCase.fromProjectDTO({ ...dto, axisSets: [], datasets: [] })
+
+      expect(result.axisSets).toEqual([])
+      expect(result.datasets).toEqual([])
+    })
+  })
+
+  test('round-trips toProjectDTO -> fromProjectDTO without losing data', () => {
+    const axisSet = new AxisSet(
+      new Axis('x1', 0, { xPx: 10, yPx: 110 }),
+      new Axis('x2', 100, { xPx: 110, yPx: 110 }),
+      new Axis('y1', 0, { xPx: 10, yPx: 110 }),
+      new Axis('y2', 100, { xPx: 10, yPx: 10 }),
+      new Axis('x2y2', -1, { xPx: -999, yPx: -999 }),
+      1,
+      'AxisSet 1',
+    )
+    const dataset = new Dataset('Dataset 1', [{ id: 1, xPx: 5, yPx: 5 }], 1)
+
+    const dto = useCase.toProjectDTO({
+      version: '1.11.2',
+      axisSets: [axisSet],
+      activeAxisSetId: 1,
+      datasets: [dataset],
+      activeDatasetId: 1,
+      canvasState: { scale: 1, manualMode: -1 },
+    })
+    const restored = useCase.fromProjectDTO(dto)
+
+    expect(restored.axisSets[0].name).toBe(axisSet.name)
+    expect(restored.axisSets[0].x1.coord).toEqual(axisSet.x1.coord)
+    expect(restored.datasets[0].name).toBe(dataset.name)
+    expect(restored.datasets[0].points).toEqual(dataset.points)
+  })
+})

--- a/packages/plot-digitizer-core/src/application/useCases/serializeProjectUseCase.ts
+++ b/packages/plot-digitizer-core/src/application/useCases/serializeProjectUseCase.ts
@@ -1,0 +1,129 @@
+import { Axis } from '../../domain/models/axis/axis'
+import { AxisSet } from '../../domain/models/axisSet/axisSet'
+import { Dataset } from '../../domain/models/dataset/dataset'
+import type { AxisSetInterface } from '../../domain/models/axisSet/axisSetInterface'
+import type { DatasetInterface } from '../../domain/models/dataset/datasetInterface'
+import type { AxisSetDTO } from '../dto/axisSetDTO'
+import type { DatasetDTO } from '../dto/datasetDTO'
+import type { CanvasStateDTO } from '../dto/canvasStateDTO'
+import type { ProjectDTO } from '../dto/projectDTO'
+
+export interface ToProjectDTOParams {
+  version: string
+  axisSets: AxisSetInterface[]
+  activeAxisSetId: number
+  datasets: DatasetInterface[]
+  activeDatasetId: number
+  canvasState: CanvasStateDTO
+}
+
+export interface FromProjectDTOResult {
+  axisSets: AxisSet[]
+  activeAxisSetId: number
+  datasets: Dataset[]
+  activeDatasetId: number
+  canvasState: CanvasStateDTO
+}
+
+// INFO: Phase 3 (docs/design/plot-digitizer-architecture.md). Ported from
+// the DTO-assembly/restoration logic that used to live inline in the host
+// app's ProjectService.exportProject()/loadProject(). ZIP packaging,
+// File/Blob handling, and the "grab the uploaded image" fallback stay in
+// the app's ProjectService — this use case only ever sees/returns plain
+// data (domain instances + DTOs), never touches JSZip, File, Blob, or the
+// DOM.
+export class SerializeProjectUseCase {
+  toProjectDTO(params: ToProjectDTOParams): ProjectDTO {
+    return {
+      version: params.version,
+      timestamp: new Date().toISOString(),
+      axisSets: params.axisSets.map(toAxisSetDTO),
+      activeAxisSetId: params.activeAxisSetId,
+      datasets: params.datasets.map(toDatasetDTO),
+      activeDatasetId: params.activeDatasetId,
+      canvasHandler: params.canvasState,
+    }
+  }
+
+  fromProjectDTO(dto: ProjectDTO): FromProjectDTOResult {
+    return {
+      axisSets: dto.axisSets.map(fromAxisSetDTO),
+      activeAxisSetId: dto.activeAxisSetId,
+      datasets: dto.datasets.map(fromDatasetDTO),
+      activeDatasetId: dto.activeDatasetId,
+      canvasState: dto.canvasHandler,
+    }
+  }
+}
+
+function toAxisSetDTO(axisSet: AxisSetInterface): AxisSetDTO {
+  return {
+    id: axisSet.id,
+    name: axisSet.name,
+    // Extract AxisDTO from AxisInterface (Entity)
+    x1: {
+      name: axisSet.x1.name,
+      value: axisSet.x1.value,
+      coord: axisSet.x1.coord,
+    },
+    x2: {
+      name: axisSet.x2.name,
+      value: axisSet.x2.value,
+      coord: axisSet.x2.coord,
+    },
+    y1: {
+      name: axisSet.y1.name,
+      value: axisSet.y1.value,
+      coord: axisSet.y1.coord,
+    },
+    y2: {
+      name: axisSet.y2.name,
+      value: axisSet.y2.value,
+      coord: axisSet.y2.coord,
+    },
+    xIsLogScale: axisSet.xIsLogScale,
+    yIsLogScale: axisSet.yIsLogScale,
+    considerGraphTilt: axisSet.considerGraphTilt,
+    pointMode: axisSet.pointMode,
+    isVisible: axisSet.isVisible,
+  }
+}
+
+function fromAxisSetDTO(dto: AxisSetDTO): AxisSet {
+  const axisSet = new AxisSet(
+    new Axis('x1', dto.x1.value, dto.x1.coord),
+    new Axis('x2', dto.x2.value, dto.x2.coord),
+    new Axis('y1', dto.y1.value, dto.y1.coord),
+    new Axis('y2', dto.y2.value, dto.y2.coord),
+    // INFO: x2y2 is a virtual axis derived at runtime, not persisted —
+    // always reset it rather than restoring it from the DTO.
+    new Axis('x2y2', -1, { xPx: -999, yPx: -999 }),
+    dto.id,
+    dto.name,
+  )
+  axisSet.xIsLogScale = dto.xIsLogScale
+  axisSet.yIsLogScale = dto.yIsLogScale
+  axisSet.considerGraphTilt = dto.considerGraphTilt
+  axisSet.pointMode = dto.pointMode
+  axisSet.isVisible = dto.isVisible
+  return axisSet
+}
+
+function toDatasetDTO(dataset: DatasetInterface): DatasetDTO {
+  return {
+    id: dataset.id,
+    name: dataset.name,
+    axisSetId: dataset.axisSetId,
+    points: dataset.points,
+    visiblePointIds: dataset.visiblePointIds,
+    manuallyAddedPointIds: dataset.manuallyAddedPointIds,
+  }
+}
+
+function fromDatasetDTO(dto: DatasetDTO): Dataset {
+  const dataset = new Dataset(dto.name, dto.points, dto.id)
+  dataset.axisSetId = dto.axisSetId
+  dataset.visiblePointIds = dto.visiblePointIds
+  dataset.manuallyAddedPointIds = dto.manuallyAddedPointIds
+  return dataset
+}

--- a/packages/plot-digitizer-core/src/index.ts
+++ b/packages/plot-digitizer-core/src/index.ts
@@ -3,9 +3,12 @@
 // Phase 1 (docs/design/plot-digitizer-architecture.md section 4.4) added
 // classification-A code (pure domain models + DOM-free application pieces).
 // Phase 2 added `PixelSourcePort` and moved `Extractor` onto it, now that it
-// no longer needs the DOM-coupled CanvasHandlerInterface. CanvasHandler
-// itself, Interpolator, ProjectService, and AutoLineDigitizerService remain
-// host-app (or later-phase) concerns.
+// no longer needs the DOM-coupled CanvasHandlerInterface. Phase 3 added
+// `SerializeProjectUseCase` (ProjectDTO ⇄ domain-model conversion, ported
+// out of the host app's ProjectService). AutoLineDigitizerService was
+// withdrawn from the product entirely (2026-08-15) and is not ported.
+// CanvasHandler itself, Interpolator, and the ZIP/File/Blob parts of
+// ProjectService remain host-app concerns.
 //
 // The host app (starry-digitizer, src/) does not import this package by its
 // npm name — it isn't published yet. It's resolved via a TS/bundler path
@@ -49,6 +52,20 @@ export type { ExtractorInterface } from './application/services/extractor/extrac
 
 // -- application/ports --------------------------------------------------------
 export type { PixelSourcePort } from './application/ports/pixelSourcePort'
+
+// -- application/useCases -------------------------------------------------
+export {
+  SerializeProjectUseCase,
+  type ToProjectDTOParams,
+  type FromProjectDTOResult,
+} from './application/useCases/serializeProjectUseCase'
+
+// -- application/dto --------------------------------------------------------
+export type { AxisDTO } from './application/dto/axisDTO'
+export type { AxisSetDTO } from './application/dto/axisSetDTO'
+export type { DatasetDTO } from './application/dto/datasetDTO'
+export type { CanvasStateDTO } from './application/dto/canvasStateDTO'
+export type { ProjectDTO } from './application/dto/projectDTO'
 
 // -- shared domain types/constants -------------------------------------------
 export type { Coord, Point, PointMode } from './domain/types'

--- a/src/application/dto/axisDTO.ts
+++ b/src/application/dto/axisDTO.ts
@@ -1,12 +1,5 @@
-import { Coord } from '@/@types/types'
-
-/**
- * DTO (Data Transfer Object) for Axis
- * Plain data representation for serialization/deserialization
- * This type contains only serializable properties
- */
-export interface AxisDTO {
-  name: string
-  value: number
-  coord: Coord
-}
+// INFO: Phase 3 (docs/design/plot-digitizer-architecture.md) — this type
+// has been moved to packages/plot-digitizer-core. This file re-exports it
+// so every existing `@/application/dto/axisDTO` import in this app keeps
+// working unchanged. Do not add logic here — edit the core package instead.
+export type { AxisDTO } from '@plot-digitizer/core'

--- a/src/application/dto/axisSetDTO.ts
+++ b/src/application/dto/axisSetDTO.ts
@@ -1,21 +1,5 @@
-import { AxisDTO } from './axisDTO'
-import { PointMode } from '@/@types/types'
-
-/**
- * DTO (Data Transfer Object) for AxisSet
- * Plain data representation for serialization/deserialization
- * Uses AxisDTO to ensure all nested properties are also serializable
- */
-export interface AxisSetDTO {
-  id: number
-  name: string
-  x1: AxisDTO
-  x2: AxisDTO
-  y1: AxisDTO
-  y2: AxisDTO
-  xIsLogScale: boolean
-  yIsLogScale: boolean
-  considerGraphTilt: boolean
-  pointMode: PointMode
-  isVisible: boolean
-}
+// INFO: Phase 3 (docs/design/plot-digitizer-architecture.md) — this type
+// has been moved to packages/plot-digitizer-core. This file re-exports it
+// so every existing `@/application/dto/axisSetDTO` import in this app keeps
+// working unchanged. Do not add logic here — edit the core package instead.
+export type { AxisSetDTO } from '@plot-digitizer/core'

--- a/src/application/dto/canvasHandlerDTO.ts
+++ b/src/application/dto/canvasHandlerDTO.ts
@@ -1,11 +1,8 @@
-import { ManualMode } from '@/@types/types'
-
-/**
- * DTO (Data Transfer Object) for CanvasHandler
- * Plain data representation for serialization/deserialization
- * This type contains only data properties needed for project persistence
- */
-export interface CanvasHandlerDTO {
-  scale: number
-  manualMode: ManualMode
-}
+// INFO: Phase 3 (docs/design/plot-digitizer-architecture.md) — this type
+// has been moved to packages/plot-digitizer-core (named `CanvasStateDTO`
+// there — core has no "CanvasHandler" concept, see
+// packages/plot-digitizer-core/src/application/dto/canvasStateDTO.ts).
+// Re-exported here under its original name so every existing
+// `@/application/dto/canvasHandlerDTO` import in this app keeps working
+// unchanged. Do not add logic here — edit the core package instead.
+export type { CanvasStateDTO as CanvasHandlerDTO } from '@plot-digitizer/core'

--- a/src/application/dto/datasetDTO.ts
+++ b/src/application/dto/datasetDTO.ts
@@ -1,15 +1,5 @@
-import { Point } from '@/@types/types'
-
-/**
- * DTO (Data Transfer Object) for Dataset
- * Plain data representation for serialization/deserialization
- * This type contains only serializable data properties
- */
-export interface DatasetDTO {
-  id: number
-  name: string
-  axisSetId: number
-  points: Point[]
-  visiblePointIds: number[]
-  manuallyAddedPointIds: number[]
-}
+// INFO: Phase 3 (docs/design/plot-digitizer-architecture.md) — this type
+// has been moved to packages/plot-digitizer-core. This file re-exports it
+// so every existing `@/application/dto/datasetDTO` import in this app keeps
+// working unchanged. Do not add logic here — edit the core package instead.
+export type { DatasetDTO } from '@plot-digitizer/core'

--- a/src/application/dto/projectDTO.ts
+++ b/src/application/dto/projectDTO.ts
@@ -1,18 +1,5 @@
-import { AxisSetDTO } from './axisSetDTO'
-import { DatasetDTO } from './datasetDTO'
-import { CanvasHandlerDTO } from './canvasHandlerDTO'
-
-/**
- * DTO (Data Transfer Object) for Project
- * Complete project data for serialization and deserialization
- * This represents the entire application state that can be saved/loaded
- */
-export interface ProjectDTO {
-  version: string
-  timestamp: string
-  axisSets: AxisSetDTO[]
-  activeAxisSetId: number
-  datasets: DatasetDTO[]
-  activeDatasetId: number
-  canvasHandler: CanvasHandlerDTO
-}
+// INFO: Phase 3 (docs/design/plot-digitizer-architecture.md) — this type
+// has been moved to packages/plot-digitizer-core. This file re-exports it
+// so every existing `@/application/dto/projectDTO` import in this app keeps
+// working unchanged. Do not add logic here — edit the core package instead.
+export type { ProjectDTO } from '@plot-digitizer/core'

--- a/src/application/services/projectService/projectService.ts
+++ b/src/application/services/projectService/projectService.ts
@@ -1,19 +1,21 @@
 import { ProjectServiceInterface } from './projectServiceInterface'
 import { ProjectDTO } from '@/application/dto/projectDTO'
-import { AxisSetDTO } from '@/application/dto/axisSetDTO'
-import { DatasetDTO } from '@/application/dto/datasetDTO'
 import { AxisSetRepositoryInterface } from '@/domain/repositories/axisSetRepository/axisSetRepositoryInterface'
 import { DatasetRepositoryInterface } from '@/domain/repositories/datasetRepository/datasetRepositoryInterface'
 import { CanvasStatePort } from './canvasStatePort'
-import { Axis } from '@/domain/models/axis/axis'
-import { AxisSet } from '@/domain/models/axisSet/axisSet'
-import { Dataset } from '@/domain/models/dataset/dataset'
+import { SerializeProjectUseCase } from '@plot-digitizer/core'
+import { ManualMode } from '@/@types/types'
 import JSZip from 'jszip'
 
 export class ProjectService implements ProjectServiceInterface {
   private axisSetRepository: AxisSetRepositoryInterface
   private datasetRepository: DatasetRepositoryInterface
   private canvasHandler: CanvasStatePort
+  // INFO: Phase 3 (docs/design/plot-digitizer-architecture.md) — the
+  // ProjectDTO ⇄ domain-model conversion itself now lives in core
+  // (SerializeProjectUseCase). This class keeps only the DOM/I-O parts:
+  // grabbing the uploaded image, ZIP packaging, and File/Blob handling.
+  private serializeProjectUseCase = new SerializeProjectUseCase()
 
   constructor(
     axisSetRepository: AxisSetRepositoryInterface,
@@ -38,58 +40,17 @@ export class ProjectService implements ProjectServiceInterface {
     }
 
     // Build project data (without image)
-    const projectData: ProjectDTO = {
+    const projectData: ProjectDTO = this.serializeProjectUseCase.toProjectDTO({
       version: '1.11.2', // TODO: Get from package.json
-      timestamp: new Date().toISOString(),
-      axisSets: this.axisSetRepository.axisSets.map(
-        (axisSet): AxisSetDTO => ({
-          id: axisSet.id,
-          name: axisSet.name,
-          // Extract AxisData (DTO) from AxisInterface (Entity)
-          x1: {
-            name: axisSet.x1.name,
-            value: axisSet.x1.value,
-            coord: axisSet.x1.coord,
-          },
-          x2: {
-            name: axisSet.x2.name,
-            value: axisSet.x2.value,
-            coord: axisSet.x2.coord,
-          },
-          y1: {
-            name: axisSet.y1.name,
-            value: axisSet.y1.value,
-            coord: axisSet.y1.coord,
-          },
-          y2: {
-            name: axisSet.y2.name,
-            value: axisSet.y2.value,
-            coord: axisSet.y2.coord,
-          },
-          xIsLogScale: axisSet.xIsLogScale,
-          yIsLogScale: axisSet.yIsLogScale,
-          considerGraphTilt: axisSet.considerGraphTilt,
-          pointMode: axisSet.pointMode,
-          isVisible: axisSet.isVisible,
-        }),
-      ),
+      axisSets: this.axisSetRepository.axisSets,
       activeAxisSetId: this.axisSetRepository.activeAxisSetId,
-      datasets: this.datasetRepository.datasets.map(
-        (dataset): DatasetDTO => ({
-          id: dataset.id,
-          name: dataset.name,
-          axisSetId: dataset.axisSetId,
-          points: dataset.points,
-          visiblePointIds: dataset.visiblePointIds,
-          manuallyAddedPointIds: dataset.manuallyAddedPointIds,
-        }),
-      ),
+      datasets: this.datasetRepository.datasets,
       activeDatasetId: this.datasetRepository.activeDataset.id,
-      canvasHandler: {
+      canvasState: {
         scale: this.canvasHandler.scale,
         manualMode: this.canvasHandler.manualMode,
       },
-    }
+    })
 
     // Create ZIP file
     const zip = new JSZip()
@@ -197,52 +158,32 @@ export class ProjectService implements ProjectServiceInterface {
     // Import project data from ZIP
     const { projectData, imageData } = await this.importProject(zipFile)
 
+    const restored = this.serializeProjectUseCase.fromProjectDTO(projectData)
+
     // Clear existing data
     this.axisSetRepository.clearAllAxisSets()
     this.datasetRepository.clearAllDatasets()
 
-    // Restore axis sets from DTO
-    for (const axisSetDTO of projectData.axisSets) {
-      const axisSet = new AxisSet(
-        new Axis('x1', axisSetDTO.x1.value, axisSetDTO.x1.coord),
-        new Axis('x2', axisSetDTO.x2.value, axisSetDTO.x2.coord),
-        new Axis('y1', axisSetDTO.y1.value, axisSetDTO.y1.coord),
-        new Axis('y2', axisSetDTO.y2.value, axisSetDTO.y2.coord),
-        new Axis('x2y2', -1, { xPx: -999, yPx: -999 }),
-        axisSetDTO.id,
-        axisSetDTO.name,
-      )
-      axisSet.xIsLogScale = axisSetDTO.xIsLogScale
-      axisSet.yIsLogScale = axisSetDTO.yIsLogScale
-      axisSet.considerGraphTilt = axisSetDTO.considerGraphTilt
-      axisSet.pointMode = axisSetDTO.pointMode
-      axisSet.isVisible = axisSetDTO.isVisible
-
+    // Restore axis sets
+    for (const axisSet of restored.axisSets) {
       this.axisSetRepository.axisSets.push(axisSet)
     }
 
     // Set active axis set
-    this.axisSetRepository.setActiveAxisSet(projectData.activeAxisSetId)
+    this.axisSetRepository.setActiveAxisSet(restored.activeAxisSetId)
 
-    // Restore datasets from DTO
-    for (const datasetDTO of projectData.datasets) {
-      const dataset = new Dataset(
-        datasetDTO.name,
-        datasetDTO.points,
-        datasetDTO.id,
-      )
-      dataset.axisSetId = datasetDTO.axisSetId
-      dataset.visiblePointIds = datasetDTO.visiblePointIds
-      dataset.manuallyAddedPointIds = datasetDTO.manuallyAddedPointIds
+    // Restore datasets
+    for (const dataset of restored.datasets) {
       this.datasetRepository.datasets.push(dataset)
     }
 
     // Set active dataset
-    this.datasetRepository.setActiveDataset(projectData.activeDatasetId)
+    this.datasetRepository.setActiveDataset(restored.activeDatasetId)
 
     // Restore canvas handler state
-    this.canvasHandler.scale = projectData.canvasHandler.scale
-    this.canvasHandler.manualMode = projectData.canvasHandler.manualMode
+    this.canvasHandler.scale = restored.canvasState.scale
+    this.canvasHandler.manualMode = restored.canvasState
+      .manualMode as ManualMode
 
     return imageData
   }


### PR DESCRIPTION
## 概要

docs/design/plot-digitizer-architecture.md の Phase 3。AI抽出関連
(`AutoLineDigitizerService`/`HttpClientPort`/`DigitizeWithAutoLineDigitizerUseCase`)
は設計ドキュメント通り既にスコープアウト済みのため、**`ProjectService` の
`ProjectDTO ⇄ ドメインモデル` 変換ロジック移植のみ**を実施。想定通り軽量な変更。

## 移植内容

- `packages/plot-digitizer-core` に `SerializeProjectUseCase` を追加
  (`application/useCases/serializeProjectUseCase.ts`)
  - `toProjectDTO()`: axisSets/datasets(ドメインモデル)+ canvasState から `ProjectDTO` を組み立てる。`timestamp` はここで生成
  - `fromProjectDTO()`: `ProjectDTO` から `AxisSet`/`Dataset` ドメインインスタンスを再構築する。x2y2仮想軸を都度リセットする既存挙動を保持
  - DTOそのものもcoreへ移植: `AxisDTO`, `AxisSetDTO`, `DatasetDTO`, `ProjectDTO`(+ `CanvasHandlerDTO` を `CanvasStateDTO` として移植。coreは「CanvasHandler」という概念を持たないため改名。`manualMode` も `ManualMode` 型ではなく汎用 `number` とした)
- 既存アプリ側のDTOファイル(`src/application/dto/*.ts`)は同名のre-exportラッパーに置換(公開importパス・挙動は無変更。`canvasHandlerDTO.ts` のみ `CanvasStateDTO as CanvasHandlerDTO` で元の名前を維持)
- `ProjectService` はDTO変換ロジックを削除し、`SerializeProjectUseCase` を呼び出す形に簡素化(107行→約60行)。ZIP化・`File`/`Blob`操作・アップロード画像取得のフォールバックはアプリ側に残置(設計方針通り)

## TDD

`serializeProjectUseCase.test.ts` を新規作成(8テスト): `toProjectDTO`/`fromProjectDTO`の基本マッピング、空配列、x2y2仮想軸の常時リセット、往復変換(round-trip)を検証。**カバレッジ100%達成**。

## codecov対策(Phase 2指摘を踏まえた事前確認)

`projectService.ts` 変更後の未カバー行(canvas fallback・`project.json`不在時などのレア異常系・`downloadZip`)を develop 時点の未カバー行と突き合わせ、**新規に追加された未カバー行が無いことを確認済み**。実質的な新規ロジックは `SerializeProjectUseCase` 側(core、カバレッジ100%)に集約されている。

## 検証

- core: `eslint` / `jest --coverage`(138 tests, 全pass。domain各層100%維持) / `tsc --noEmit`
- app: `eslint` / `vue-tsc --noEmit` / `jest`(47 tests, 全pass。`projectService.test.ts` の10テストは無変更のまま全pass = 挙動が完全に同一であることを確認) / `npm run depcruise`(違反0件) / `vite build -c vite.library.config.ts`(成功)
  (以上Haikuサブエージェントに委譲・複数回実施)
- **Cypress E2E**: 5 spec / 12 tests(8 passing, 4 pending=既存の意図的skip)、**全spec成功**

## 影響範囲

- アプリの公開挙動は無変更(re-exportラッパー・DTO変換ロジックの移設のみ)
- `project.json` のファイル形式(キー名含む)は無変更 — 既存のエクスポート済みプロジェクトファイルとの互換性を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)