### PR TITLE
訪問数を数える(Vercel Web Analytics)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@handsontable/vue3": "^13.1.0",
     "@mdi/font": "^7.2.96",
+    "@vercel/analytics": "^2.0.1",
     "browser-sync": "^3.0.2",
     "curve-interpolator": "^3.3.0",
     "handsontable": "^13.1.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,8 @@ import * as directives from 'vuetify/directives'
 import colors from 'vuetify/lib/util/colors'
 import { aliases, mdi } from 'vuetify/iconsets/mdi'
 
+import { inject as injectAnalytics } from '@vercel/analytics'
+
 import { interpolator } from './instanceStore/applicationServiceInstances'
 
 //INFO: initialize application services
@@ -45,6 +47,18 @@ const vuetify = createVuetify({
     },
   },
 })
+
+/*
+ * 訪問数を数える(Vercel Web Analytics)。
+ *
+ * **ここはアプリの入り口(`src/main.ts`)だけ。**このリポジトリは
+ * `library-build/entry.ts` からライブラリも配布しているので、そちらには入れない。
+ * **人の作ったページに、こちらの計測を紛れ込ませることになる。**
+ *
+ * Cookieを置かず、個人を追わないので同意バナーは要らない。
+ * 開発中は何も送らない。
+ */
+injectAnalytics()
 
 const app = createApp(App).use(vuetify)
 app.mount('#app')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,6 +1762,11 @@
     "@typescript-eslint/types" "6.5.0"
     eslint-visitor-keys "^3.4.1"
 
+"@vercel/analytics@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-2.0.1.tgz"
+  integrity sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==
+
 "@vitejs/plugin-vue@^4.2.3":
   version "4.3.4"
   resolved "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.3.4.tgz"


### PR DESCRIPTION
**`develop` 宛です。`main` への反映(本番リリース)はしていません** — 司令塔の指示により、人の承認をお待ちします。

## やったこと

アプリの入り口 `src/main.ts` で `inject()` を呼ぶだけです。

## ⚠️ 先に確認いただきたいこと: 既に Google Analytics が入っています

`index.html` に gtag(`G-9QDX98GT94`)が入っています。このまま入れると**二重計測**になります。

同じ理由で、**chika-forecast と dive-forecast は今回スキップ**しました(既存GAを維持)。
このリポジトリは名指しで対象に挙がっていたのでPRは出しますが、
**同じ方針なら閉じてください。**判断はお任せします。

## ライブラリには入れていません

このリポジトリは `library-build/entry.ts` からライブラリも配布しています。
**人の作ったページに、こちらの計測を紛れ込ませることになる**ので、そちらには入れていません。

```
library-build/dist/index.js       "vercel" の出現 0
library-build/dist/index.umd.cjs  "vercel" の出現 0
dist/assets/index-*.js            "vercel" の出現 1  ← アプリ側にだけ入っている
```

## ロックファイルを手で編集しています

`yarn add` をそのまま走らせると、環境依存の再正規化で **yarn.lock が742行書き換わりました**
(esbuild のプラットフォーム別エントリなど、この変更と無関係な差分)。
歴史のあるリポジトリに出す差分として雑なので、**package.json と yarn.lock を手で最小限だけ**編集しています。

```
package.json  1行追加
yarn.lock     5行追加
```

`yarn install --frozen-lockfile` が通り、**ロックが書き換わらないこと**を確認済みです。

## 確認したこと

- `vite build`(アプリ)通過
- `vite build -c vite.library.config.ts`(ライブラリ)通過
- `tsc --noEmit` のエラーは**変更前後とも1件で同数**(vuetify の型で、元からあるもの)

## 選んだ理由

Cookieを置かず、個人を特定できるものを集めず、サイトをまたいでも追いません。
そのため同意バナーが要りません。開発中は何も送りません。
